### PR TITLE
Load counter metrics from external JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # demo
+
+## Metrics configuration
+
+The animated counter values on the homepage are loaded from `metrics.json`.
+Update this file (or serve the same structure from a backend) to change the
+numbers displayed for saved CO₂, completed energy audits, and faculty members.

--- a/index.html
+++ b/index.html
@@ -282,17 +282,27 @@
                 };
                 window.requestAnimationFrame(step);
             }
-            const counterObserver = new IntersectionObserver((entries) => {
-                entries.forEach(entry => {
-                    if (entry.isIntersecting) {
-                        animateValue(document.getElementById('co2-saved'), 0, 15000, 2000);
-                        animateValue(document.getElementById('energy-audits'), 0, 30, 2000);
-                        animateValue(document.getElementById('faculty-members'), 0, 10, 2000);
-                        counterObserver.unobserve(entry.target);
-                    }
-                });
-            }, { threshold: 0.5 });
-            counterObserver.observe(document.getElementById('home'));
+            async function initCounters() {
+                try {
+                    const response = await fetch('metrics.json', { cache: 'no-cache' });
+                    const metrics = await response.json();
+                    const counterObserver = new IntersectionObserver((entries) => {
+                        entries.forEach(entry => {
+                            if (entry.isIntersecting) {
+                                Object.entries(metrics).forEach(([id, value]) => {
+                                    const el = document.getElementById(id);
+                                    if (el) animateValue(el, 0, value, 2000);
+                                });
+                                counterObserver.unobserve(entry.target);
+                            }
+                        });
+                    }, { threshold: 0.5 });
+                    counterObserver.observe(document.getElementById('home'));
+                } catch (err) {
+                    console.error('Failed to load metrics', err);
+                }
+            }
+            initCounters();
 
             const teamGrid = document.getElementById('team-grid');
             const teamFilters = document.getElementById('team-filters');

--- a/metrics.json
+++ b/metrics.json
@@ -1,0 +1,5 @@
+{
+  "co2-saved": 15000,
+  "energy-audits": 30,
+  "faculty-members": 10
+}


### PR DESCRIPTION
## Summary
- Replace hard-coded counter values with numbers fetched from `metrics.json`
- Initialize counters with fetched data on page load and animate when visible
- Document where counter data lives and how to update it

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68af15ad47bc83298418dc7b6a86b64f