### PR TITLE
Add client-side validation to contact form

### DIFF
--- a/index.html
+++ b/index.html
@@ -179,11 +179,12 @@
                  <div data-aos="fade-up" class="text-center mb-12"><h2 class="text-4xl font-bold text-white">Get In Touch</h2><p class="text-green-400">Let's build a sustainable future together.</p></div>
                 <div class="flex flex-col md:flex-row gap-12 items-center">
                     <div data-aos="fade-right" class="md:w-1/2 text-lg">
-                        <form action="#" method="POST" class="space-y-6">
-                            <input type="text" placeholder="Your Name" class="w-full p-4 rounded-lg bg-gray-800/50 border border-gray-700 focus:outline-none focus:ring-2 focus:ring-green-500 text-gray-200 placeholder-gray-500">
-                            <input type="email" placeholder="Your Email" class="w-full p-4 rounded-lg bg-gray-800/50 border border-gray-700 focus:outline-none focus:ring-2 focus:ring-green-500 text-gray-200 placeholder-gray-500">
-                            <textarea placeholder="Your Message" rows="5" class="w-full p-4 rounded-lg bg-gray-800/50 border border-gray-700 focus:outline-none focus:ring-2 focus:ring-green-500 text-gray-200 placeholder-gray-500"></textarea>
+                        <form id="contact-form" action="https://example.com/contact" method="POST" class="space-y-6">
+                            <input name="name" id="name" type="text" placeholder="Your Name" required class="w-full p-4 rounded-lg bg-gray-800/50 border border-gray-700 focus:outline-none focus:ring-2 focus:ring-green-500 text-gray-200 placeholder-gray-500">
+                            <input name="email" id="email" type="email" placeholder="Your Email" required class="w-full p-4 rounded-lg bg-gray-800/50 border border-gray-700 focus:outline-none focus:ring-2 focus:ring-green-500 text-gray-200 placeholder-gray-500">
+                            <textarea name="message" id="message" placeholder="Your Message" rows="5" required class="w-full p-4 rounded-lg bg-gray-800/50 border border-gray-700 focus:outline-none focus:ring-2 focus:ring-green-500 text-gray-200 placeholder-gray-500"></textarea>
                             <button type="submit" class="w-full bg-green-600 hover:bg-green-700 text-white font-semibold py-4 px-8 rounded-lg transition text-lg accent-glow">Send Message</button>
+                            <p id="form-status" class="text-sm text-center hidden"></p>
                         </form>
                     </div>
                     <div data-aos="fade-left" class="md:w-1/2 text-lg text-gray-300">
@@ -352,6 +353,45 @@
                 });
             }, { rootMargin: "-50% 0px -50% 0px" });
             sections.forEach(sec => scrollObserver.observe(sec));
+
+            const contactForm = document.getElementById('contact-form');
+            const formStatus = document.getElementById('form-status');
+
+            contactForm.addEventListener('submit', async (e) => {
+                e.preventDefault();
+                formStatus.textContent = '';
+                formStatus.classList.add('hidden');
+                const name = contactForm.name.value.trim();
+                const email = contactForm.email.value.trim();
+                const message = contactForm.message.value.trim();
+                if (!name || !email || !message) {
+                    formStatus.textContent = 'Please fill in all fields.';
+                    formStatus.classList.remove('text-green-400');
+                    formStatus.classList.add('text-red-400');
+                    formStatus.classList.remove('hidden');
+                    return;
+                }
+                try {
+                    const response = await fetch(contactForm.action, {
+                        method: 'POST',
+                        body: new FormData(contactForm)
+                    });
+                    if (response.ok) {
+                        formStatus.textContent = 'Message sent successfully!';
+                        formStatus.classList.remove('text-red-400');
+                        formStatus.classList.add('text-green-400');
+                        formStatus.classList.remove('hidden');
+                        contactForm.reset();
+                    } else {
+                        throw new Error('Network response was not ok');
+                    }
+                } catch (error) {
+                    formStatus.textContent = 'There was an error sending your message.';
+                    formStatus.classList.remove('text-green-400');
+                    formStatus.classList.add('text-red-400');
+                    formStatus.classList.remove('hidden');
+                }
+            });
 
             // Initial Render
             renderTeam('creedFaculty');


### PR DESCRIPTION
## Summary
- add meaningful name attributes and backend action to contact form
- implement client-side validation with user feedback messages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af15af9a5483298019315444a0d366