### PR TITLE
Add light and dark theme toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="dark">
-  <!-- Set to dark mode permanently -->
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="assets/CREED_LOGO_1.svg" />
@@ -8,6 +7,18 @@
     <title>
       CREED - Center of Research for Energy Efficiency and Decarbonization
     </title>
+    <script>
+      tailwind.config = { darkMode: "class" };
+      if (
+        localStorage.theme === "dark" ||
+        (!("theme" in localStorage) &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches)
+      ) {
+        document.documentElement.classList.add("dark");
+      } else {
+        document.documentElement.classList.remove("dark");
+      }
+    </script>
     <script src="https://cdn.tailwindcss.com"></script>
     <link
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;900&display=swap"
@@ -16,20 +27,26 @@
     <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet" />
     <style>
       :root {
-        --bg-dark: #0a0a1a;
-        --text-dark-primary: #e0e0e0;
         --accent: #16a34a;
         --accent-hover: #15803d;
-        --card-dark: rgba(255, 255, 255, 0.05);
-        --border-dark: rgba(255, 255, 255, 0.1);
+        --bg: #ffffff;
+        --text-primary: #1f2937;
+        --card: rgba(0, 0, 0, 0.05);
+        --border: rgba(0, 0, 0, 0.1);
+      }
+      html.dark {
+        --bg: #0a0a1a;
+        --text-primary: #e0e0e0;
+        --card: rgba(255, 255, 255, 0.05);
+        --border: rgba(255, 255, 255, 0.1);
       }
       html {
         scroll-behavior: smooth;
       }
       body {
         font-family: "Inter", sans-serif;
-        background-color: var(--bg-dark);
-        color: var(--text-dark-primary);
+        background-color: var(--bg);
+        color: var(--text-primary);
       }
 
       .hero-bg {
@@ -37,13 +54,16 @@
           url("assets/hero-bg.jpg") no-repeat center center/cover;
       }
       .glass-effect {
-        background: var(--card-dark);
-        border: 1px solid var(--border-dark);
+        background: var(--card);
+        border: 1px solid var(--border);
       }
       .header-scrolled {
-        background-color: rgba(10, 10, 26, 0.8);
+        background-color: rgba(255, 255, 255, 0.8);
         backdrop-filter: blur(10px);
         -webkit-backdrop-filter: blur(10px);
+      }
+      html.dark .header-scrolled {
+        background-color: rgba(10, 10, 26, 0.8);
       }
       .nav-link.active {
         color: var(--accent);
@@ -70,7 +90,7 @@
         width: 8px;
       }
       ::-webkit-scrollbar-track {
-        background: var(--bg-dark);
+        background: var(--bg);
       }
       ::-webkit-scrollbar-thumb {
         background: var(--accent);
@@ -80,6 +100,31 @@
         background: var(--accent-hover);
       }
 
+      html:not(.dark) .text-white {
+        color: #1f2937;
+      }
+      html:not(.dark) .text-gray-300 {
+        color: #374151;
+      }
+      html:not(.dark) .bg-gray-900 {
+        background-color: #ffffff;
+      }
+      html:not(.dark) .bg-gray-800 {
+        background-color: #f3f4f6;
+      }
+      html:not(.dark) .bg-gray-800\/50 {
+        background-color: rgba(243, 244, 246, 0.5);
+      }
+      html:not(.dark) .border-gray-700 {
+        border-color: #d1d5db;
+      }
+      html:not(.dark) .text-gray-200 {
+        color: #1f2937;
+      }
+      html:not(.dark) .hover\:bg-gray-800:hover {
+        background-color: #e5e7eb;
+      }
+    
       /* Cursor Glow Effect */
       #cursor-glow {
         position: fixed;
@@ -144,8 +189,30 @@
             >Contact</a
           >
         </nav>
-        <div class="md:hidden flex items-center gap-4">
-          <button id="mobile-menu-button" class="text-white">
+        <div class="flex items-center gap-4">
+          <button id="theme-toggle" class="text-white">
+            <svg
+              id="theme-toggle-light-icon"
+              class="w-6 h-6 hidden"
+              fill="currentColor"
+              viewBox="0 0 20 20"
+            >
+              <path
+                d="M10 15a5 5 0 100-10 5 5 0 000 10z"
+              />
+            </svg>
+            <svg
+              id="theme-toggle-dark-icon"
+              class="w-6 h-6 hidden"
+              fill="currentColor"
+              viewBox="0 0 20 20"
+            >
+              <path
+                d="M17.293 13.293A8 8 0 016.707 2.707 8 8 0 1017.293 13.293z"
+              />
+            </svg>
+          </button>
+          <button id="mobile-menu-button" class="text-white md:hidden">
             <svg
               class="w-6 h-6"
               fill="none"
@@ -620,6 +687,29 @@
     <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
     <script>
       document.addEventListener("DOMContentLoaded", function () {
+        const themeToggle = document.getElementById("theme-toggle");
+        const lightIcon = document.getElementById("theme-toggle-light-icon");
+        const darkIcon = document.getElementById("theme-toggle-dark-icon");
+
+        function updateThemeIcons() {
+          if (document.documentElement.classList.contains("dark")) {
+            lightIcon.classList.remove("hidden");
+            darkIcon.classList.add("hidden");
+          } else {
+            darkIcon.classList.remove("hidden");
+            lightIcon.classList.add("hidden");
+          }
+        }
+
+        updateThemeIcons();
+        themeToggle?.addEventListener("click", () => {
+          document.documentElement.classList.toggle("dark");
+          localStorage.theme = document.documentElement.classList.contains("dark")
+            ? "dark"
+            : "light";
+          updateThemeIcons();
+        });
+
         AOS.init({ duration: 800, once: true });
 
         // --- Cursor Glow ---


### PR DESCRIPTION
## Summary
- add Tailwind dark mode configuration with initial theme detection
- introduce theme toggle button and styling overrides for light mode
- implement script to switch themes and persist user preference

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b2c597d8148329a1cbe18afc7ec7da